### PR TITLE
Pipe stdout/stderr streams of first run to terminal when benchmarking

### DIFF
--- a/Cilkscale_vis/runner.py
+++ b/Cilkscale_vis/runner.py
@@ -7,10 +7,22 @@ import csv
 
 logger = logging.getLogger(__name__)
 
+def print_stdout_stderr(out, err, bin_instrument, bin_args):
+  print()
+  print(">> STDOUT (" + bin_instrument + " " + " ".join(bin_args) + ")")
+  print(str(out,"utf-8"), file=sys.stdout, end='')
+  print("<< END STDOUT")
+  print()
+  print(">> STDERR (" + bin_instrument + " " + " ".join(bin_args) + ")")
+  print(str(err,"utf-8"), file=sys.stderr, end='')
+  print("<< END STDERR")
+  print()
+  return
+
 # generate csv with parallelism numbers
 def get_parallelism(bin_instrument, bin_args, out_csv):
   out,err = run_command("CILKSCALE_OUT=" + out_csv + " " + bin_instrument + " " + " ".join(bin_args))
-  return
+  return out,err
 
 def run_command(cmd, asyn = False):
   proc = subprocess.Popen([cmd], shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -72,7 +84,10 @@ def get_cpu_ordering():
 
 def run(bin_instrument, bin_bench, bin_args, out_csv="out.csv", cpu_counts=None):
   # get parallelism
-  get_parallelism(bin_instrument, bin_args, out_csv)
+  out,err = get_parallelism(bin_instrument, bin_args, out_csv)
+
+  # print execution output (stdout/stderr) as user feedback
+  print_stdout_stderr(out, err, bin_instrument, bin_args)
 
   # get benchmark runtimes
   NCPUS = get_n_cpus()


### PR DESCRIPTION
Added a simple function (`print_stdout_stderr`) in `runner.py` to echo stdout/stderr program output to the user when benchmarking.  The echoed streams correspond to the first execution (from within the `get_parallelism` function).

This can help the user understand what is being analyzed by cilkscale---as I found out when I was trying to run a program without the requisite input argument and ended up wandering why the cilkscale output was not as expected...

Example 1 (correct execution):
````
python3 /home/ailiop/project/opencilk/productivity-tools/Cilkscale_vis/cilkscale.py -c ./cilk-reduce-accum-cs -b ./cilk-reduce-accum-bench -ocsv cs-agg.csv -oplot cs-plot.pdf --args 10000000 -rplot 0,1,2,3
Namespace(args=['10000000'], cilkscale='./cilk-reduce-accum-cs', cilkscale_benchmark='./cilk-reduce-accum-bench', cpu_counts=None, output_csv='cs-agg.csv', output_plot='cs-plot.pdf', rows_to_plot='0,1,2,3')

>> STDOUT (./cilk-reduce-accum-cs 10000000)
Sum(n) for n = 1 to 10000000

...true solution...
...cilk_for without critical section handling (*WRONG*)...
   - FAIL!
   - elapsed time: 0.648 ms
...cilk_for with POSIX lock...
   - PASS!
   - elapsed time: 743.786 ms
...cilk_for with reducer...
   - PASS!
   - elapsed time: 17.363 ms

<< END STDOUT

>> STDERR (./cilk-reduce-accum-cs 10000000)
<< END STDERR

INFO:runner:Generating scalability data for 4 cpus.
INFO:runner:CILK_NWORKERS=1 taskset -c 0 ./cilk-reduce-accum-bench 10000000
INFO:runner:CILK_NWORKERS=2 taskset -c 0,1 ./cilk-reduce-accum-bench 10000000
INFO:runner:CILK_NWORKERS=3 taskset -c 0,1,2 ./cilk-reduce-accum-bench 10000000
INFO:runner:CILK_NWORKERS=4 taskset -c 0,1,2,3 ./cilk-reduce-accum-bench 10000000
INFO:plotter:Generating plot
````

Example 2 (wrong execution):
````
python3 /home/ailiop/project/opencilk/productivity-tools/Cilkscale_vis/cilkscale.py -c ./cilk-reduce-accum-cs -b ./cilk-reduce-accum-bench -ocsv cs-agg.csv -oplot cs-plot.pdf -rplot 0,1,2,3
Namespace(args='', cilkscale='./cilk-reduce-accum-cs', cilkscale_benchmark='./cilk-reduce-accum-bench', cpu_counts=None, output_csv='cs-agg.csv', output_plot='cs-plot.pdf', rows_to_plot='0,1,2,3')

>> STDOUT (./cilk-reduce-accum-cs )
<< END STDOUT

>> STDERR (./cilk-reduce-accum-cs )
Usage: cilk-reduce-accum N
	 (N: sum upper limit)
<< END STDERR

INFO:runner:Generating scalability data for 4 cpus.
INFO:runner:CILK_NWORKERS=1 taskset -c 0 ./cilk-reduce-accum-bench 
INFO:runner:CILK_NWORKERS=2 taskset -c 0,1 ./cilk-reduce-accum-bench 
INFO:runner:CILK_NWORKERS=3 taskset -c 0,1,2 ./cilk-reduce-accum-bench 
INFO:runner:CILK_NWORKERS=4 taskset -c 0,1,2,3 ./cilk-reduce-accum-bench 
INFO:plotter:Generating plot
````