### PR TITLE
Add `-rplot all` option to Cilkscale visualizer script

### DIFF
--- a/Cilkscale_vis/cilkscale.py
+++ b/Cilkscale_vis/cilkscale.py
@@ -13,7 +13,7 @@ def main():
   ap.add_argument("--cpu-counts", "-cpus", help="comma-separated list of cpu counts to use for benchmarking")
   ap.add_argument("--output-csv", "-ocsv", help="csv file for output data", default="out.csv")
   ap.add_argument("--output-plot", "-oplot", help="plot file dest", default="plot.pdf")
-  ap.add_argument("--rows-to-plot", "-rplot", help="comma-separated list of rows to generate plots for (i.e. 1,2,3)", default="0")
+  ap.add_argument("--rows-to-plot", "-rplot", help="comma-separated list of rows to generate plots for (i.e. 0,1,2); or `all` to plot all rows", default="all")
   ap.add_argument("--args", "-a", nargs="*", help="binary arguments", default="")
 
   args = ap.parse_args()
@@ -40,7 +40,9 @@ def main():
     # generate plot
     # (out_plot defaults to plot.pdf)
     # (rows defaults to just the last row in the csv)
-    rows_to_plot = list(map(int, args.rows_to_plot.split(",")))
+    rows_to_plot = args.rows_to_plot
+    if rows_to_plot != "all":
+      rows_to_plot = list(map(int, rows_to_plot.split(",")))
     plot(out_csv, out_plot, rows_to_plot, cpus)
 
 if __name__ == '__main__':

--- a/Cilkscale_vis/plotter.py
+++ b/Cilkscale_vis/plotter.py
@@ -19,11 +19,15 @@ def bound_runtime(T1, PAR, P):
   return Tp
 
 def sanitize_rows_to_plot(out_csv, rows_to_plot):
-  # if any row numbers are invalid, set them to the last row by default
+  # if any row numbers are invalid, set them to the last row by default;
+  # "all" is a special case for plotting all rows in the CSV
   num_rows = 0
   with open(out_csv, "r") as out_csv_file:
     rows = csv.reader(out_csv_file, delimiter=",")
     num_rows = len(list(rows))
+
+    if rows_to_plot == "all":
+      return set(range(1, num_rows))
 
     new_rows_to_plot = set()
     for r in rows_to_plot:


### PR DESCRIPTION
Add a `--rows-to-plot all` or `-rplot all` option to the `cilkscale.py` script.  This allows the user to specify plotting all lines in the Cilkscale-exported CSV (i.e., regions that were instrumented with the Cilkscale `wsp_***` API) without having to manually enumerate them as `-rplot 0,1,2,...`.

The `-rplot all` option value is also set as the default.

_Note:_ The `-rplot` option does not accept any non-integer value other than `all` (e.g., `-rplot SomeOtherString`); and `all` cannot be used together with integer values (e.g., `-rplot all,1`, etc).  In such cases, the script crashes **after** generating the scalability analysis data CSV for all specified number of Cilk workers.