### PR TITLE
Code cleanup and add another Cilksan hook

### DIFF
--- a/cilksan/libhooks.cpp
+++ b/cilksan/libhooks.cpp
@@ -338,6 +338,23 @@ CILKSAN_API void __csan_llvm_x86_sse2_pause(const csi_id_t call_id,
   return;
 }
 
+CILKSAN_API void __csan_llvm_aarch64_hint(const csi_id_t call_id,
+                                          const csi_id_t func_id,
+                                          unsigned MAAP_count,
+                                          const call_prop_t prop, int32_t arg) {
+  switch (arg) {
+  case 1: { // yield instruction
+    // Nothing to do to check a yield instruction.
+    return;
+  }
+  default: {
+    // Unknown hint.  Call the default libhook.
+    __csan_default_libhook(call_id, func_id, MAAP_count);
+    return;
+  }
+  }
+}
+
 CILKSAN_API void __csan_llvm_stacksave(const csi_id_t call_id,
                                        const csi_id_t func_id,
                                        unsigned MAAP_count,

--- a/cilksan/libhooks.cpp
+++ b/cilksan/libhooks.cpp
@@ -330,6 +330,14 @@ CILKSAN_API void __csan_llvm_x86_avx2_gather_d_pd_256(
       call_id, MAAP_count, prop, result, vbase, base, index, mask, scale);
 }
 
+CILKSAN_API void __csan_llvm_x86_sse2_pause(const csi_id_t call_id,
+                                            const csi_id_t func_id,
+                                            unsigned MAAP_count,
+                                            const call_prop_t prop) {
+  // Nothing to do to check a pause instruction.
+  return;
+}
+
 CILKSAN_API void __csan_llvm_stacksave(const csi_id_t call_id,
                                        const csi_id_t func_id,
                                        unsigned MAAP_count,

--- a/cilkscale/cilkscale.cpp
+++ b/cilkscale/cilkscale.cpp
@@ -173,7 +173,7 @@ CilkscaleImpl_t::CilkscaleImpl_t() {
   shadow_stack = new shadow_stack_t(frame_type::MAIN);
 #else
   shadow_stack = new shadow_stack_reducer();
-  __cilkrts_reducer_register(shadow_stack, sizeof *shadow_stack,
+  __cilkrts_reducer_register(shadow_stack, sizeof(*shadow_stack),
                              &shadow_stack_t::identity,
                              &shadow_stack_t::reduce);
 #endif
@@ -184,10 +184,10 @@ CilkscaleImpl_t::CilkscaleImpl_t() {
 
 #if !SERIAL_TOOL
   outf_red = new out_reducer((outf.is_open() ? outf : outs));
-  __cilkrts_reducer_register
-    (outf_red, sizeof *outf_red,
-     &cilk::ostream_view<char, std::char_traits<char>>::identity,
-     &cilk::ostream_view<char, std::char_traits<char>>::reduce);
+  __cilkrts_reducer_register(
+      outf_red, sizeof(*outf_red),
+      &cilk::ostream_view<char, std::char_traits<char>>::identity,
+      &cilk::ostream_view<char, std::char_traits<char>>::reduce);
 #endif
 
   shadow_stack->push(frame_type::SPAWNER);

--- a/cilkscale/shadow_stack.h
+++ b/cilkscale/shadow_stack.h
@@ -72,9 +72,6 @@ struct shadow_stack_t {
   cilkscale_timer_t start;
   cilkscale_timer_t stop;
 
-  // // Running total of work.
-  // cilk_time_t running_work = cilk_time_t::zero();
-
 private:
   // Dynamic array of shadow-stack frames.
   shadow_stack_frame_t *frames;

--- a/test/cilksan/TestCases/intrinsics.c
+++ b/test/cilksan/TestCases/intrinsics.c
@@ -1,0 +1,32 @@
+// RUN: %clang_cilksan -fopencilk -O0 %s -o %t
+// RUN: %run %t 2>&1 | FileCheck %s
+
+#include <cilk/cilk.h>
+#include <stdio.h>
+
+_Atomic int x = 0;
+
+void foo(void) {
+  while (!x) {
+#ifdef __SSE__
+    __builtin_ia32_pause();
+#endif
+#ifdef __aarch64__
+    __builtin_arm_yield();
+#endif
+  }
+  ++x;
+}
+
+int main(int argc, char *argv[]) {
+  cilk_spawn { ++x; }
+  foo();
+  cilk_sync;
+  printf("x=%d\n", x);
+  return 0;
+}
+
+// CHECK: Running Cilksan race detector
+// CHECK-NEXT: x=2
+// CHECK: Cilksan detected 0 distinct races.
+// CHECK-NEXT: Cilksan suppressed 0 duplicate race reports.


### PR DESCRIPTION
This PR cleans up some code and adds Cilksan hooks for the x86 `pause` instruction and the AArch64 `yield` instruction.  This PR fixes issue OpenCilk/infrastructure#21.