### PR TITLE
macOS arm64 libhooks

### DIFF
--- a/cilksan/CMakeLists.txt
+++ b/cilksan/CMakeLists.txt
@@ -52,7 +52,7 @@ set(CILKSAN_DYNAMIC_LINK_FLAGS ${CILKSAN_COMMON_LINK_FLAGS})
 # Setup flags and defs for cilktool bitcode build
 set(CILKSAN_BITCODE_CFLAGS ${CILKSAN_CFLAGS} -emit-llvm)
 set(CILKSAN_BITCODE_DEFINITIONS ${CILKSAN_COMMON_DEFINITIONS}
-    "CILKSAN_VIS=")
+    "CILKSAN_VIS=__attribute__((noinline))")
 
 # Build Cilksan runtimes shipped with Clang.
 add_cilktools_component(cilksan)

--- a/cilksan/cilksan.cpp
+++ b/cilksan/cilksan.cpp
@@ -1073,7 +1073,7 @@ void CilkSanImpl_t::init() {
     }
   }
 
-  std::cout << "Running Cilksan race detector.\n";
+  std::cerr << "Running Cilksan race detector.\n";
 
   // these are true upon creation of the stack
   cilksan_assert(frame_stack.size() == 1);

--- a/cilksan/driver.h
+++ b/cilksan/driver.h
@@ -117,4 +117,7 @@ static inline bool is_on_stack(uintptr_t addr) {
   return (addr <= stack_high_addr && addr >= stack_low_addr);
 }
 
+CILKSAN_API void __cilksan_begin_atomic();
+CILKSAN_API void __cilksan_end_atomic();
+
 #endif // __DRIVER_H__

--- a/cilksan/driver.h
+++ b/cilksan/driver.h
@@ -117,6 +117,10 @@ static inline bool is_on_stack(uintptr_t addr) {
   return (addr <= stack_high_addr && addr >= stack_low_addr);
 }
 
+CILKSAN_API bool __cilksan_should_check(void);
+CILKSAN_API void __cilksan_record_alloc(void *addr, size_t size);
+CILKSAN_API void __cilksan_record_free(void *ptr);
+
 CILKSAN_API void __cilksan_begin_atomic();
 CILKSAN_API void __cilksan_end_atomic();
 


### PR DESCRIPTION
This PR adds hooks for library and intrinsic functions that arise on macOS arm64.

This PR also modifies Cilksan's bitcode file to prevent inlining hooks.  Inlining these hooks would require the Cilksan library to expose many more symbols, and it would introduce correctness problems.