### PR TITLE
Miscellaneous updates

### DIFF
--- a/cilksan/cilksan_internal.h
+++ b/cilksan/cilksan_internal.h
@@ -140,18 +140,14 @@ public:
   void do_enter_helper(unsigned num_sync_reg);
   void do_detach();
   void do_detach_continue();
-  void do_loop_begin() {
-    start_new_loop = true;
-  }
+  void do_loop_begin() { start_new_loop = true; }
   void do_loop_iteration_begin(unsigned num_sync_reg);
   void do_loop_iteration_end();
   void do_loop_end(unsigned sync_reg);
   bool in_loop() const {
     return LOOP_FRAME == frame_stack.head()->frame_data.frame_type;
   }
-  bool handle_loop() const {
-    return in_loop() || (true == start_new_loop);
-  }
+  bool handle_loop() const { return in_loop() || start_new_loop; }
   void do_sync(unsigned sync_reg);
   void do_return();
   void do_leave(unsigned sync_reg);

--- a/cilksan/dictionary.h
+++ b/cilksan/dictionary.h
@@ -16,8 +16,8 @@
 using DS_t = DisjointSet_t<call_stack_t>;
 
 class MemoryAccess_t {
-  static constexpr unsigned VERSION_SHIFT = 48;
-  static constexpr unsigned TYPE_SHIFT = 44;
+  static constexpr unsigned VERSION_SHIFT = 8 * (sizeof(uintptr_t) - sizeof(version_t));
+  static constexpr unsigned TYPE_SHIFT = VERSION_SHIFT - 4;
   static constexpr csi_id_t ID_MASK = ((1UL << TYPE_SHIFT) - 1);
   static constexpr csi_id_t TYPE_MASK = ((1UL << VERSION_SHIFT) - 1) & ~ID_MASK;
   static constexpr csi_id_t UNKNOWN_CSI_ACC_ID = UNKNOWN_CSI_ID & ID_MASK;
@@ -112,9 +112,7 @@ public:
       return MAType_t::UNKNOWN;
     return static_cast<MAType_t>((ver_acc_id & TYPE_MASK) >> TYPE_SHIFT);
   }
-  uint16_t getVersion() const {
-    return getVersionFromVerFunc();
-  }
+  version_t getVersion() const { return getVersionFromVerFunc(); }
   AccessLoc_t getLoc() const {
     if (!isValid())
       return AccessLoc_t();

--- a/cilksan/driver.cpp
+++ b/cilksan/driver.cpp
@@ -471,7 +471,8 @@ CILKSAN_API void __csan_after_call(const csi_id_t call_id,
 // __csan_detach_continue() can cause parallel loops to fail to be properly
 // transformed.  We forbid inlining these functions for now.
 CILKSAN_API __attribute__((noinline)) void
-__csan_detach(const csi_id_t detach_id, const unsigned sync_reg) {
+__csan_detach(const csi_id_t detach_id, const unsigned sync_reg,
+              const detach_prop_t prop) {
   if (!should_check())
     return;
 
@@ -488,7 +489,7 @@ __csan_detach(const csi_id_t detach_id, const unsigned sync_reg) {
   // this notes the change of peer sets.
   parallel_execution.back() = 1;
 
-  if (!CilkSanImpl.handle_loop())
+  if (!prop.for_tapir_loop_body)
     // Push the detach onto the call stack.
     CilkSanImpl.record_call(detach_id, SPAWN);
 }
@@ -607,7 +608,7 @@ __csan_detach_continue(const csi_id_t detach_continue_id,
     CilkSanImpl.do_sync(sync_reg);
   }
 
-  if (!CilkSanImpl.handle_loop()) {
+  if (!prop.for_tapir_loop_body) {
     CilkSanImpl.record_call_return(detach_id, SPAWN);
     CilkSanImpl.do_detach_continue();
   }

--- a/cilksan/frame_data.h
+++ b/cilksan/frame_data.h
@@ -161,7 +161,7 @@ typedef struct FrameData_t {
     cilksan_assert(nullptr != Iterbag);
     return Iterbag->inc_version();
   }
-  bool check_parallel_iter(const SBag_t *LCA, uint16_t version) const {
+  bool check_parallel_iter(const SBag_t *LCA, version_t version) const {
     if (!is_loop_frame())
       return false;
     return (LCA == Iterbag) && (version < LCA->get_version());

--- a/cilksan/libhooks.cpp
+++ b/cilksan/libhooks.cpp
@@ -2373,6 +2373,7 @@ CILKSAN_API void __csan_hypotl(const csi_id_t call_id, const csi_id_t func_id,
   return;
 }
 
+#if defined(__linux__)
 CILKSAN_API void __csan__IO_getc(const csi_id_t call_id, const csi_id_t func_id,
                                  unsigned MAAP_count, const call_prop_t prop,
                                  int result, _IO_FILE *__fp) {
@@ -2389,6 +2390,7 @@ CILKSAN_API void __csan__IO_getc(const csi_id_t call_id, const csi_id_t func_id,
 
   check_write_bytes(call_id, fp_MAAPVal, __fp, 1);
 }
+#endif
 
 CILKSAN_API void __csan_isascii(const csi_id_t call_id, const csi_id_t func_id,
                                 unsigned MAAP_count, const call_prop_t prop,

--- a/cilksan/libhooks.cpp
+++ b/cilksan/libhooks.cpp
@@ -2373,6 +2373,23 @@ CILKSAN_API void __csan_hypotl(const csi_id_t call_id, const csi_id_t func_id,
   return;
 }
 
+CILKSAN_API void __csan__IO_getc(const csi_id_t call_id, const csi_id_t func_id,
+                                 unsigned MAAP_count, const call_prop_t prop,
+                                 int result, _IO_FILE *__fp) {
+  START_HOOK(call_id);
+
+  MAAP_t fp_MAAPVal = MAAP_t::ModRef;
+  if (MAAP_count > 0) {
+    fp_MAAPVal = MAAPs.back().second;
+    MAAPs.pop();
+  }
+
+  if (!is_execution_parallel())
+    return;
+
+  check_write_bytes(call_id, fp_MAAPVal, __fp, 1);
+}
+
 CILKSAN_API void __csan_isascii(const csi_id_t call_id, const csi_id_t func_id,
                                 unsigned MAAP_count, const call_prop_t prop,
                                 int result, int ch) {

--- a/cilkscale/cilkscale.cpp
+++ b/cilkscale/cilkscale.cpp
@@ -354,7 +354,8 @@ void __csi_func_exit(const csi_id_t func_exit_id, const csi_id_t func_id,
 }
 
 CILKTOOL_API
-void __csi_detach(const csi_id_t detach_id, const int32_t *has_spawned) {
+void __csi_detach(const csi_id_t detach_id, const int32_t *has_spawned,
+                  const detach_prop_t prop) {
   tool->shadow_stack->stop.gettime();
 
 #if TRACE_CALLS

--- a/include/csi/csi.h
+++ b/include/csi/csi.h
@@ -91,6 +91,12 @@ typedef struct {
 } loop_exit_prop_t;
 
 typedef struct {
+  // The detach corresponds with a Tapir loop body.
+  unsigned for_tapir_loop_body : 1;
+  uint64_t _padding : 63;
+} detach_prop_t;
+
+typedef struct {
   // The task is the body of a Tapir loop
   unsigned is_tapir_loop_body : 1;
   // Number of sync regions in this function.
@@ -107,7 +113,9 @@ typedef struct {
 typedef struct {
   // The detach continue identifies the unwind destination of a detach.
   unsigned is_unwind : 1;
-  uint64_t _padding : 63;
+  // The detach continue corresponds with the detach of a Tapir loop.
+  unsigned for_tapir_loop_body : 1;
+  uint64_t _padding : 62;
 } detach_continue_prop_t;
 
 typedef struct {
@@ -243,7 +251,8 @@ WEAK void __csi_after_store(const csi_id_t store_id, const void *addr,
 
 ///-----------------------------------------------------------------------------
 /// Hooks for Tapir control flow.
-WEAK void __csi_detach(const csi_id_t detach_id, const int32_t *has_spawned);
+WEAK void __csi_detach(const csi_id_t detach_id, const int32_t *has_spawned,
+                       const detach_prop_t prop);
 
 WEAK void __csi_task(const csi_id_t task_id, const csi_id_t detach_id,
                      const task_prop_t prop);

--- a/test/cilksan/TestCases/call-once-c11.c
+++ b/test/cilksan/TestCases/call-once-c11.c
@@ -1,5 +1,6 @@
 // RUN: %clang_cilksan -fopencilk -Og %s -o %t
 // RUN: %run %t 2>&1 | FileCheck %s
+// UNSUPPORTED: darwin
 
 #include <cilk/cilk.h>
 #include <stdio.h>

--- a/test/cilksan/TestCases/reducer-lock-test.cpp
+++ b/test/cilksan/TestCases/reducer-lock-test.cpp
@@ -9,7 +9,7 @@
 #include <pthread.h>
 
 int main() {
-  cilk::opadd_reducer<int> sum;
+  cilk::opadd_reducer<int> sum = 0;
   int rsum = 0;
   int lsum = 0;
   pthread_mutex_t mtex;


### PR DESCRIPTION
This PR contains a few miscellaneous updates:
- Add library-function hooks for `setbuf`, `setvbuf`, `system`, and `_IO_getc`.
- Add properties to instrumentation hooks for detach and detach-continuations to identify detaches that are part of a Tapir parallel loop.  These properties make it simpler for tools to distinguish such detaches from detaches occur in the body of the parallel loop.