### PR TITLE
[cilksan] Clean up #include's in Cilksan source and header files.

### DIFF
--- a/cilksan/cilksan.cpp
+++ b/cilksan/cilksan.cpp
@@ -1,8 +1,3 @@
-#include <cstdio>
-#include <cstdlib>
-#include <iostream>
-#include <inttypes.h>
-
 #include "cilksan_internal.h"
 #include "debug_util.h"
 #include "disjointset.h"
@@ -12,6 +7,9 @@
 #include "simple_shadow_mem.h"
 #include "spbag.h"
 #include "stack.h"
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
 
 // FILE io used to print error messages
 FILE *err_io = stderr;

--- a/cilksan/cilksan_internal.h
+++ b/cilksan/cilksan_internal.h
@@ -2,10 +2,6 @@
 #ifndef __CILKSAN_INTERNAL_H__
 #define __CILKSAN_INTERNAL_H__
 
-#include <cstdio>
-#include <iostream>
-#include <unordered_map>
-
 #include "addrmap.h"
 #include "csan.h"
 #include "dictionary.h"
@@ -15,6 +11,8 @@
 #include "locksets.h"
 #include "shadow_mem_allocator.h"
 #include "stack.h"
+#include <cstdio>
+#include <unordered_map>
 
 extern bool CILKSAN_INITIALIZED;
 

--- a/cilksan/csanrt.cpp
+++ b/cilksan/csanrt.cpp
@@ -1,8 +1,7 @@
-#include <cstdlib>
-#include <assert.h>
-#include <atomic>
-#include <iostream>
 #include "csan.h"
+#include <atomic>
+#include <cassert>
+#include <cstdlib>
 
 #define CSIRT_API __attribute__((visibility("default")))
 

--- a/cilksan/debug_util.cpp
+++ b/cilksan/debug_util.cpp
@@ -1,10 +1,10 @@
+#include "debug_util.h"
+#include "driver.h"
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
-#include <strings.h>
+#include <cstring>
 #include <signal.h>
-#include "debug_util.h"
-#include "driver.h"
 
 /*
   static void print_bt(FILE *f) {

--- a/cilksan/debug_util.h
+++ b/cilksan/debug_util.h
@@ -1,7 +1,7 @@
 #ifndef __DEBUG_UTIL_H__
 #define __DEBUG_UTIL_H__
 
-#include <assert.h>
+#include <cassert>
 
 #ifndef CILKSAN_DEBUG
 #ifdef _DEBUG

--- a/cilksan/dictionary.h
+++ b/cilksan/dictionary.h
@@ -2,16 +2,14 @@
 #ifndef __DICTIONARY__
 #define __DICTIONARY__
 
-#include <cstdio>
-#include <cstdlib>
-#include <iostream>
-#include <inttypes.h>
-
 #include "debug_util.h"
 #include "disjointset.h"
 #include "frame_data.h"
-#include "race_info.h"
 #include "spbag.h"
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
 
 using DS_t = DisjointSet_t<call_stack_t>;
 

--- a/cilksan/disjointset.h
+++ b/cilksan/disjointset.h
@@ -3,13 +3,13 @@
 #ifndef _DISJOINTSET_H
 #define _DISJOINTSET_H
 
-#include <cstdio>
-#include <cstdlib>
-#include <cstdint>
-
 #include "aligned_alloc.h"
 #include "debug_util.h"
 #include "race_info.h"
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
 
 #if DISJOINTSET_DEBUG
 #define WHEN_DISJOINTSET_DEBUG(stmt) do { stmt; } while(0)

--- a/cilksan/driver.cpp
+++ b/cilksan/driver.cpp
@@ -1,20 +1,15 @@
-#include <cstdarg>
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
-#include <fstream>
-#include <dlfcn.h>
-#include <map>
-#include <sys/mman.h>
-#include <unistd.h>
-
 #include "checking.h"
 #include "cilksan_internal.h"
 #include "debug_util.h"
 #include "driver.h"
-#include "race_detect_update.h"
-#include "simple_shadow_mem.h"
 #include "stack.h"
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <dlfcn.h>
+#include <sys/mman.h>
+#include <unistd.h>
 
 // FILE io used to print error messages
 extern FILE *err_io;

--- a/cilksan/driver.h
+++ b/cilksan/driver.h
@@ -2,14 +2,12 @@
 #ifndef __DRIVER_H__
 #define __DRIVER_H__
 
-#include <csi/csi.h>
-#include <cstdint>
-#include <utility>
-
-#include "addrmap.h"
 #include "cilksan_internal.h"
 #include "locksets.h"
 #include "stack.h"
+#include <csi/csi.h>
+#include <cstdint>
+#include <utility>
 
 #ifndef CILKSAN_VIS
 #define CILKSAN_VIS __attribute__((visibility("default")))

--- a/cilksan/frame_data.h
+++ b/cilksan/frame_data.h
@@ -2,8 +2,6 @@
 #ifndef __FRAME_DATA_H__
 #define __FRAME_DATA_H__
 
-#include "cilksan_internal.h"
-#include "csan.h"
 #include "disjointset.h"
 #include "hypertable.h"
 #include "spbag.h"

--- a/cilksan/hook_format.inc
+++ b/cilksan/hook_format.inc
@@ -10,9 +10,13 @@
 // and http://pubs.opengroup.org/onlinepubs/9699919799/functions/fprintf.html
 // with a few common GNU extensions.
 
-#include <cstdarg>
-
 #include "debug_util.h"
+#include "driver.h"
+#include <csi/csi.h>
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
 
 #define CHECK(p) cilksan_assert(p)
 #define CHECK_GT(n, v) cilksan_assert(n > 0)
@@ -149,7 +153,7 @@ static int format_get_value_size(char convSpecifier,
     case 'z':
       return sizeof(size_t);
     case 't':
-      return sizeof(ptrdiff_t);
+      return sizeof(std::ptrdiff_t);
     case 0:
       return sizeof(int);
     default:

--- a/cilksan/hyperobject_base.h
+++ b/cilksan/hyperobject_base.h
@@ -2,11 +2,8 @@
 #ifndef _HYPEROBJECT_BASE
 #define _HYPEROBJECT_BASE
 
-#include <cstddef>
-#include <cstdint>
-#include <cstdlib>
-
 #include <cilk/cilk_api.h>
+#include <cstdlib>
 
 // Reducer data.
 //

--- a/cilksan/hypertable.h
+++ b/cilksan/hypertable.h
@@ -2,8 +2,9 @@
 #ifndef _HYPERTABLE_H
 #define _HYPERTABLE_H
 
-#include <cstdint>
 #include "hyperobject_base.h"
+#include <cassert>
+#include <cstdint>
 
 // Helper methods for testing and setting keys.
 static const uintptr_t KEY_EMPTY = 0UL;

--- a/cilksan/libhooks.cpp
+++ b/cilksan/libhooks.cpp
@@ -1,13 +1,12 @@
+#include "cilksan_internal.h"
+#include "debug_util.h"
+#include "driver.h"
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <sys/stat.h>
 #include <utime.h>
-
-#include "cilksan_internal.h"
-#include "debug_util.h"
-#include "driver.h"
 
 CILKSAN_API void __csan_default_libhook(const csi_id_t call_id,
                                         const csi_id_t func_id,

--- a/cilksan/locksets.h
+++ b/cilksan/locksets.h
@@ -3,12 +3,12 @@
 #ifndef _LOCKSETS_H
 #define _LOCKSETS_H
 
-#include <assert.h>
+#include "debug_util.h"
+#include "dictionary.h"
+#include <cassert>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
-#include <inttypes.h>
-
-#include "debug_util.h"
 
 enum IntersectionResult_t : uint8_t {
   EMPTY = 0x0,

--- a/cilksan/print_addr.cpp
+++ b/cilksan/print_addr.cpp
@@ -1,18 +1,13 @@
+#include "csan.h"
+#include "cilksan_internal.h"
 #include <cstring>
 #include <fstream>
 #include <iostream>
-#include <string>
-#include <sstream>
-#include <unordered_map>
 #include <memory>
-
-#include <inttypes.h>
-#include <unistd.h>
 #include <signal.h>
-
-#include "csan.h"
-#include "cilksan_internal.h"
-#include "debug_util.h"
+#include <sstream>
+#include <unistd.h>
+#include <unordered_map>
 
 extern bool is_running_under_rr;
 

--- a/cilksan/race_detect_update.h
+++ b/cilksan/race_detect_update.h
@@ -2,8 +2,8 @@
 #ifndef __RACE_DETECT_UPDATE__
 #define __RACE_DETECT_UPDATE__
 
-#include "csan.h"
 #include "simple_shadow_mem.h"
+#include <csi/csi.h>
 
 // Check races on memory [addr, addr+mem_size) with this read access.  Once done
 // checking, update shadow_memory with this new read access.

--- a/cilksan/race_info.h
+++ b/cilksan/race_info.h
@@ -2,6 +2,10 @@
 #ifndef __RACE_INFO_H__
 #define __RACE_INFO_H__
 
+#include "debug_util.h"
+#include <csi/csi.h>
+#include <ostream>
+
 #ifndef CHECK_EQUIVALENT_STACKS
 #define CHECK_EQUIVALENT_STACKS false
 #endif

--- a/cilksan/reducers.cpp
+++ b/cilksan/reducers.cpp
@@ -1,10 +1,9 @@
-#include <cstdarg>
-#include <cstdio>
-#include <cstdlib>
-
 #include "cilksan_internal.h"
 #include "debug_util.h"
 #include "driver.h"
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
 
 // Hooks for handling reducer hyperobjects.
 

--- a/cilksan/shadow_mem_allocator.h
+++ b/cilksan/shadow_mem_allocator.h
@@ -2,13 +2,11 @@
 #ifndef __SHADOW_MEM_ALLOCATOR_H__
 #define __SHADOW_MEM_ALLOCATOR_H__
 
-#include <cstddef>
-#include <cstdlib>
-#include <iostream>
-#include <inttypes.h>
-
 #include "aligned_alloc.h"
 #include "dictionary.h"
+#include <cstddef>
+#include <cstdlib>
+#include <inttypes.h>
 
 // The memory-access-line allocator is dedicated to allocating specific
 // fixed-size arrays of MemoryAccess_t objects, e.g., MemoryAccess_t[1],

--- a/cilksan/simple_shadow_mem.h
+++ b/cilksan/simple_shadow_mem.h
@@ -2,11 +2,6 @@
 #ifndef __SIMPLE_SHADOW_MEM__
 #define __SIMPLE_SHADOW_MEM__
 
-#include <cstdlib>
-#include <iostream>
-#include <inttypes.h>
-#include <sys/mman.h>
-
 #include "checking.h"
 #include "cilksan_internal.h"
 #include "debug_util.h"
@@ -14,6 +9,8 @@
 #include "locksets.h"
 #include "shadow_mem_allocator.h"
 #include "vector.h"
+#include <cstdlib>
+#include <sys/mman.h>
 
 class SimpleShadowMem;
 

--- a/cilksan/spbag.h
+++ b/cilksan/spbag.h
@@ -3,15 +3,13 @@
 #ifndef _SPBAG_H
 #define _SPBAG_H
 
-#include <cstdio>
-#include <cstdint>
-#include <cstdlib>
-#include <string>
-#include <inttypes.h>
-
 #include "debug_util.h"
 #include "disjointset.h"
 #include "race_info.h"
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #define UNINIT_STACK_PTR ((uintptr_t)0LL)
 

--- a/cilksan/stack.h
+++ b/cilksan/stack.h
@@ -3,12 +3,12 @@
 #ifndef _STACK_H
 #define _STACK_H
 
-#include <assert.h>
+#include "debug_util.h"
+#include <cassert>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
-#include <inttypes.h>
-
-#include "debug_util.h"
+#include <utility>
 
 /*
  * Stack data structure for storing and maintaining data

--- a/cilksan/vector.h
+++ b/cilksan/vector.h
@@ -3,12 +3,10 @@
 #ifndef _VECTOR_H
 #define _VECTOR_H
 
-#include <assert.h>
+#include "debug_util.h"
+#include <cassert>
 #include <cstdio>
 #include <cstdlib>
-#include <inttypes.h>
-
-#include "debug_util.h"
 
 // Vector data structure for storing and maintaining data
 // associated with the call vector.


### PR DESCRIPTION
This PR fixes OpenCilk/productivity-tools#47 and generally fixes the `#include`s in the Cilksan codebase to use C++ headers and use headers if and only if they are needed.