### PR TITLE
Cilkscale cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Building a standalone copy of the OpenCilk tools
+
+These instructions assume that you are building the OpenCilk tools
+using the OpenCilk compiler.
+
+## Building with CMake
+
+1. Make a build directory at the top level and enter it:
+
+   ```console
+   mkdir build
+   cd build
+   ```
+
+2. Configure CMake.  Make sure to specify `CMAKE_C_COMPILER`,
+   `CMAKE_CXX_COMPILER`, and `LLVM_CMAKE_DIR` to point to the
+   corresponding build or installation of the OpenCilk compiler
+   binaries.  In addition, set `CMAKE_BUILD_TYPE` to specify the build
+   type, such as, `Debug`, for an unoptimized build with all
+   assertions enabled; `Release`, for an fully optimized build with
+   assertions disabled; or `RelWithDebInfo`, to enable some
+   optimizations and assertions.  (The default build type is `Debug`.)
+
+   Example configuration:
+
+   ```console
+   cmake -DCMAKE_C_COMPILER=/path/to/opencilk-project/build/bin/clang -DCMAKE_C_COMPILER=/path/to/opencilk-project/build/bin/clang++ -DCMAKE_BUILD_TYPE=Release -DLLVM_CMAKE_DIR=/path/to/opencilk-project/build ../
+
+3. Build the runtime:
+
+   ```console
+   cmake --build . -- -j<number of build threads>
+   ```
+
+To clean the build, run `cmake --build . --target clean` from the build
+directory.

--- a/cilkscale/benchmark.cpp
+++ b/cilkscale/benchmark.cpp
@@ -1,9 +1,3 @@
-#include <cassert>
-#include <cstdint>
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
-
 // Ensure that __cilkscale__ is defined, so we can provide a nontrivial
 // definition of getworkspan().
 #ifndef __cilkscale__
@@ -11,11 +5,16 @@
 #endif
 
 #include "cilkscale_timer.h"
+#include <cassert>
 #include <csi/csi.h>
-#include <iostream>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <fstream>
+#include <iostream>
 
-#define CILKTOOL_API extern "C" __attribute__((visibility("default")))
+#define CILKTOOL_VISIBLE __attribute__((visibility("default")))
+#define CILKTOOL_API extern "C" CILKTOOL_VISIBLE
 
 #ifndef SERIAL_TOOL
 #define SERIAL_TOOL 1
@@ -25,30 +24,32 @@
 #define TRACE_CALLS 0
 #endif
 
-#include <cilk/cilk_api.h>
-#if !SERIAL_TOOL
+#if SERIAL_TOOL
+#include <cilk/cilk_stub.h>
+#else // !SERIAL_TOOL
+#include <cilk/cilk.h>
 #include <cilk/ostream_reducer.h>
 using out_reducer = cilk::ostream_reducer<char>;
-#endif
+#endif // SERIAL_TOOL
 
 ///////////////////////////////////////////////////////////////////////////
 // Data structures for timing.
 
-#if !SERIAL_TOOL
+#if SERIAL_TOOL
+using cilkscale_timer_reducer = cilkscale_timer_t;
+#else
 // Simple reducer for a cilkscale_timer.
 //
 // This reducer ensures that each stolen subcomputation gets a separate
 // cilkscale_timer object for probing the computation.
-static void timer_identity(void *view) {
-  new (view) cilkscale_timer_t();
-}
-static void timer_reduce(void *left, void *right) {
-  static_cast<cilkscale_timer_t *>(right)->~cilkscale_timer_t();
+static void timerIdentity(void *View) { new (View) cilkscale_timer_t(); }
+static void timerReduce(void *Left, void *Right) {
+  static_cast<cilkscale_timer_t *>(Right)->~cilkscale_timer_t();
 }
 
-using cilkscale_timer_reducer =
-  cilkscale_timer_t _Hyperobject(timer_identity, timer_reduce);
-  
+using cilkscale_timer_reducer = cilkscale_timer_t cilk_reducer(timerIdentity,
+                                                               timerReduce);
+
 #endif
 
 // Suppress diagnostic warning that reducer callbacks are not implemented for
@@ -61,89 +62,78 @@ using cilkscale_timer_reducer =
 // std::ostream and a std::ofstream, only after the standard libraries they rely
 // on have been initialized, and to destroy those structures before those
 // libraries are deinitialized.
-class BenchmarkImpl_t {
+class BenchmarkImplT {
 public:
   // Timer for tracking execution time.
-  cilkscale_timer_t start, stop;
+  cilkscale_timer_t Start, Stop;
 #if SERIAL_TOOL
   cilkscale_timer_t timer;
 #else
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcilk-ignored"
-  cilkscale_timer_reducer timer;
+  cilkscale_timer_reducer Timer;
 #pragma clang diagnostic pop
 #endif
 
-  std::ostream &outs = std::cout;
-  std::ofstream outf;
+  std::ostream &Outs = std::cout;
+  std::ofstream Outf;
 #if !SERIAL_TOOL
-  out_reducer *outf_red = nullptr;
+  out_reducer OutfRed;
 #endif
 
-  std::basic_ostream<char> *out_view() {
+  std::basic_ostream<char> &outView() {
 #if !SERIAL_TOOL
-    // TODO: The compiler does not correctly bind the hyperobject
-    // type to a reference, otherwise a reference return value would
-    // be more conventional C++.
-    if (outf_red)
-      return &*outf_red;
+    return OutfRed;
 #endif
-    if (outf.is_open())
-      return &outf;
-    return &outs;
+    if (Outf.is_open())
+      return Outf;
+    return Outs;
   }
 
-  BenchmarkImpl_t();
-  ~BenchmarkImpl_t();
+  BenchmarkImplT(const char *OutputFilename = nullptr);
+  ~BenchmarkImplT();
 };
 
 #pragma clang diagnostic pop
 
 // Top-level benchmarking tool.
-static BenchmarkImpl_t *create_tool(void) {
-  if (!__cilkrts_is_initialized())
-    // If the OpenCilk runtime is not yet initialized, then csi_init will
-    // register a call to init_tool to initialize the tool after the runtime is
-    // initialized.
-    return nullptr;
-
-  // Otherwise, ordered dynamic initalization should ensure that it's safe to
-  // create the tool.
-  return new BenchmarkImpl_t();
+static BenchmarkImplT *createTool(void) {
+  // Ordered dynamic initalization should ensure that it's safe to create the
+  // tool.
+  return new BenchmarkImplT(getenv("CILKSCALE_OUT"));
 }
-static BenchmarkImpl_t *tool = create_tool();
+static BenchmarkImplT *Tool = createTool();
 
-static bool TOOL_INITIALIZED = false;
+static bool CILKSCALE_BENCHMARK_INITIALIZED = false;
 
 ///////////////////////////////////////////////////////////////////////////
 // Routines to results
 
 // Ensure that a proper header has been emitted to OS.
-template<class Out>
-static void ensure_header(Out &OS) {
-  static bool PRINT_STARTED = false;
-  if (PRINT_STARTED)
+template <class Out> static void ensureHeader(Out &OS) {
+  static bool PrintStarted = false;
+  if (PrintStarted)
     return;
 
   OS << "tag,time (" << cilk_time_t::units << ")\n";
 
-  PRINT_STARTED = true;
+  PrintStarted = true;
 }
 
 // Emit the given results to OS.
-template<class Out>
-static void print_results(Out &OS, const char *tag, cilk_time_t time) {
-  OS << tag << "," << time << "\n";
+template <class Out>
+static void printResults(Out &OS, const char *Tag, cilk_time_t Time) {
+  OS << Tag << "," << Time << "\n";
 }
 
 // Emit the results from the overall program execution to the proper output
 // stream.
-static void print_analysis(void) {
-  assert(TOOL_INITIALIZED);
+static void printAnalysis(void) {
+  assert(CILKSCALE_BENCHMARK_INITIALIZED);
 
-  std::basic_ostream<char> &output = *tool->out_view();
-  ensure_header(output);
-  print_results(output, "", elapsed_time(&tool->stop, &tool->start));
+  std::basic_ostream<char> &OS = Tool->outView();
+  ensureHeader(OS);
+  printResults(OS, "", elapsed_time(&Tool->Stop, &Tool->Start));
 }
 
 ///////////////////////////////////////////////////////////////////////////
@@ -152,38 +142,22 @@ static void print_analysis(void) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 
-BenchmarkImpl_t::BenchmarkImpl_t() {
-  const char *envstr = getenv("CILKSCALE_OUT");
-  if (envstr)
-    outf.open(envstr);
-
+BenchmarkImplT::BenchmarkImplT(const char *OutputFilename)
+    : Outf(OutputFilename)
 #if !SERIAL_TOOL
-  __cilkrts_reducer_register
-    (&timer, sizeof timer, timer_identity, timer_reduce);
-
-  outf_red = new out_reducer((outf.is_open() ? outf : outs));
-  __cilkrts_reducer_register
-    (outf_red, sizeof *outf_red,
-     &cilk::ostream_view<char, std::char_traits<char>>::identity,
-     &cilk::ostream_view<char, std::char_traits<char>>::reduce);
+      ,
+      OutfRed(Outf.is_open() ? Outf : Outs)
 #endif
-
-  start.gettime();
+{
+  Start.gettime();
 }
 
-BenchmarkImpl_t::~BenchmarkImpl_t() {
-  stop.gettime();
-  print_analysis();
-  
-  if (outf.is_open())
-    outf.close();
+BenchmarkImplT::~BenchmarkImplT() {
+  Stop.gettime();
+  printAnalysis();
 
-#if !SERIAL_TOOL
-  __cilkrts_reducer_unregister(outf_red);
-  delete outf_red;
-  outf_red = nullptr;
-  __cilkrts_reducer_unregister(&timer);
-#endif
+  if (Outf.is_open())
+    Outf.close();
 }
 
 #pragma clang diagnostic pop
@@ -191,19 +165,13 @@ BenchmarkImpl_t::~BenchmarkImpl_t() {
 ///////////////////////////////////////////////////////////////////////////
 // Hooks for operating the tool.
 
-// Custom function to intialize tool after the OpenCilk runtime is initialized.
-static void init_tool(void) {
-  assert(nullptr == tool && "Tool already initialized");
-  tool = new BenchmarkImpl_t();
-}
-
-static void destroy_tool(void) {
-  if (tool) {
-    delete tool;
-    tool = nullptr;
+static void destroyTool(void) {
+  if (Tool) {
+    delete Tool;
+    Tool = nullptr;
   }
 
-  TOOL_INITIALIZED = false;
+  CILKSCALE_BENCHMARK_INITIALIZED = false;
 }
 
 CILKTOOL_API void __csi_init() {
@@ -211,16 +179,13 @@ CILKTOOL_API void __csi_init() {
   fprintf(stderr, "__csi_init()\n");
 #endif
 
-  if (!__cilkrts_is_initialized())
-    __cilkrts_atinit(init_tool);
+  atexit(destroyTool);
 
-  __cilkrts_atexit(destroy_tool);
-
-  TOOL_INITIALIZED = true;
+  CILKSCALE_BENCHMARK_INITIALIZED = true;
 }
 
-CILKTOOL_API void __csi_unit_init(const char *const file_name,
-                                  const instrumentation_counts_t counts) {
+CILKTOOL_API void __csi_unit_init(const char *const FileName,
+                                  const instrumentation_counts_t Counts) {
   return;
 }
 
@@ -228,52 +193,48 @@ CILKTOOL_API void __csi_unit_init(const char *const file_name,
 // Probes and associated routines
 
 CILKTOOL_API wsp_t wsp_getworkspan() CILKSCALE_NOTHROW {
-  if (!tool)
+  if (!Tool)
     return wsp_zero();
 
-  tool->timer.gettime();
-  duration_t time_since_start = elapsed_time(&tool->timer, &tool->start);
-  wsp_t result = {cilk_time_t(time_since_start).get_raw_duration(), 0, 0};
+  Tool->Timer.gettime();
+  duration_t TimeSinceStart = elapsed_time(&Tool->Timer, &Tool->Start);
+  wsp_t Result = {cilk_time_t(TimeSinceStart).get_raw_duration(), 0, 0};
 
-  return result;
+  return Result;
 }
 
-__attribute__((visibility("default"))) wsp_t &
-operator+=(wsp_t &lhs, const wsp_t &rhs) noexcept {
-  lhs.work += rhs.work;
-  return lhs;
+CILKTOOL_VISIBLE wsp_t &operator+=(wsp_t &Lhs, const wsp_t &Rhs) noexcept {
+  Lhs.work += Rhs.work;
+  return Lhs;
 }
 
-__attribute__((visibility("default"))) wsp_t &
-operator-=(wsp_t &lhs, const wsp_t &rhs) noexcept {
-  lhs.work -= rhs.work;
-  return lhs;
+CILKTOOL_VISIBLE wsp_t &operator-=(wsp_t &Lhs, const wsp_t &Rhs) noexcept {
+  Lhs.work -= Rhs.work;
+  return Lhs;
 }
 
-__attribute__((visibility("default"))) std::ostream &
-operator<<(std::ostream &OS, const wsp_t &pt) {
-  OS << cilk_time_t(pt.work);
+CILKTOOL_VISIBLE std::ostream &operator<<(std::ostream &OS, const wsp_t &Pt) {
+  OS << cilk_time_t(Pt.work);
   return OS;
 }
 
-__attribute__((visibility("default"))) std::ofstream &
-operator<<(std::ofstream &OS, const wsp_t &pt) {
-  OS << cilk_time_t(pt.work);
+CILKTOOL_VISIBLE std::ofstream &operator<<(std::ofstream &OS, const wsp_t &Pt) {
+  OS << cilk_time_t(Pt.work);
   return OS;
 }
 
-CILKTOOL_API wsp_t wsp_add(wsp_t lhs, wsp_t rhs) CILKSCALE_NOTHROW {
-  lhs.work += rhs.work;
-  return lhs;
+CILKTOOL_API wsp_t wsp_add(wsp_t Lhs, wsp_t Rhs) CILKSCALE_NOTHROW {
+  Lhs.work += Rhs.work;
+  return Lhs;
 }
 
-CILKTOOL_API wsp_t wsp_sub(wsp_t lhs, wsp_t rhs) CILKSCALE_NOTHROW {
-  lhs.work -= rhs.work;
-  return lhs;
+CILKTOOL_API wsp_t wsp_sub(wsp_t Lhs, wsp_t Rhs) CILKSCALE_NOTHROW {
+  Lhs.work -= Rhs.work;
+  return Lhs;
 }
 
-CILKTOOL_API void wsp_dump(wsp_t wsp, const char *tag) {
-  std::basic_ostream<char> &output = *tool->out_view();
-  ensure_header(output);
-  print_results(output, tag, cilk_time_t(wsp.work));
+CILKTOOL_API void wsp_dump(wsp_t Wsp, const char *Tag) {
+  std::basic_ostream<char> &Output = Tool->outView();
+  ensureHeader(Output);
+  printResults(Output, Tag, cilk_time_t(Wsp.work));
 }

--- a/cilkscale/cilkscale_timer.h
+++ b/cilkscale/cilkscale_timer.h
@@ -4,8 +4,8 @@
 
 #include <cilk/cilkscale.h>
 #include <csi/csi.h>
-#include <iostream>
 #include <fstream>
+#include <iostream>
 
 #define RDTSC 1
 #define CLOCK 2
@@ -23,7 +23,7 @@
 #endif
 
 ///////////////////////////////////////////////////////////////////////////
-// Data structures and helper methods for time of user strands.
+// Data structures and helper methods to time user strands.
 #if CSCALETIMER == RDTSC || CSCALETIMER == INST
 using duration_t = raw_duration_t;
 #else // CSCALETIMER == CLOCK
@@ -32,6 +32,8 @@ using duration_t = std::chrono::nanoseconds;
 static_assert(sizeof(duration_t) == sizeof(raw_duration_t),
               "Mistmatched sizes for time values.");
 
+// Class representing time for a user strand.  This class is designed to hide
+// the specific details of which timer is used.
 class cilk_time_t {
   duration_t val;
 
@@ -50,12 +52,14 @@ public:
 #endif // CSCALETIMER
   }
 
+  // Comparison operators between cilk_time_t's and duration_t's.
   friend bool operator==(const cilk_time_t &lhs, const duration_t &rhs) {
     return lhs.val == rhs;
   }
   friend bool operator>(const cilk_time_t &lhs, const duration_t &rhs) {
     return lhs.val > rhs;
   }
+  // Arithmetic operators between cilk_time_t's and duration_t's.
   friend cilk_time_t operator+(cilk_time_t lhs, const duration_t &rhs) {
     lhs.val += rhs;
     return lhs;
@@ -73,13 +77,14 @@ public:
     return *this;
   }
 
+  // Comparison operators between cilk_time_t's.
   friend bool operator==(const cilk_time_t &lhs, const cilk_time_t &rhs) {
     return lhs.val == rhs.val;
   }
   friend bool operator>(const cilk_time_t &lhs, const cilk_time_t &rhs) {
     return lhs.val > rhs.val;
   }
-
+  // Arithmetic operators between cilk_time_t's.
   friend cilk_time_t operator+(cilk_time_t lhs, const cilk_time_t &rhs) {
     lhs.val += rhs.val;
     return lhs;

--- a/cilkscale/shadow_stack.h
+++ b/cilkscale/shadow_stack.h
@@ -2,6 +2,7 @@
 #ifndef INCLUDED_SHADOW_STACK_H
 #define INCLUDED_SHADOW_STACK_H
 
+#include <cilk/cilk.h>
 #include "cilkscale_timer.h"
 
 #ifndef SERIAL_TOOL
@@ -199,7 +200,7 @@ public:
   }
 };
 
-typedef shadow_stack_t _Hyperobject(shadow_stack_t::identity,
+typedef shadow_stack_t cilk_reducer(shadow_stack_t::identity,
                                     shadow_stack_t::reduce)
   shadow_stack_reducer;
 

--- a/cilkscale/shadow_stack.h
+++ b/cilkscale/shadow_stack.h
@@ -2,12 +2,16 @@
 #ifndef INCLUDED_SHADOW_STACK_H
 #define INCLUDED_SHADOW_STACK_H
 
+#include "cilkscale_timer.h"
 #include <cassert>
 #include <cilk/cilk.h>
-#include "cilkscale_timer.h"
 
 #ifndef SERIAL_TOOL
 #define SERIAL_TOOL 1
+#endif
+
+#if SERIAL_TOOL
+#include <cilk/cilk_stub.h>
 #endif
 
 #ifndef TRACE_CALLS

--- a/cilkscale/shadow_stack.h
+++ b/cilkscale/shadow_stack.h
@@ -2,6 +2,7 @@
 #ifndef INCLUDED_SHADOW_STACK_H
 #define INCLUDED_SHADOW_STACK_H
 
+#include <cassert>
 #include <cilk/cilk.h>
 #include "cilkscale_timer.h"
 


### PR DESCRIPTION
This PR cleans up the cilkscale and cilkscale-benchmark tool codebases based on LLVM code style and support for Cilk hyperobject class members.

This PR also adds a README about how to build the Cilk tools as a standalone project, similarly to cheetah.