### PR TITLE
OpenCilk v3 rc1 bug fixes

### DIFF
--- a/.github/workflows/small-cilkapps.yml
+++ b/.github/workflows/small-cilkapps.yml
@@ -35,6 +35,7 @@ jobs:
       with:
         projects: clang
         os_list: '${{ matrix.os }}'
+        extra_cmake_args: -DLLVM_TARGETS_TO_BUILD=host
     - name: Build cheetah
       id: build-cheetah
       uses: OpenCilk/actions/build-cheetah@main

--- a/cilksan/driver.cpp
+++ b/cilksan/driver.cpp
@@ -2,7 +2,9 @@
 #include "cilksan_internal.h"
 #include "debug_util.h"
 #include "driver.h"
+#include "race_info.h"
 #include "stack.h"
+#include <csi/csi.h>
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
@@ -1095,7 +1097,23 @@ CILKSAN_API void __cilksan_record_alloc(void *addr, size_t size) {
 
 CILKSAN_API void __cilksan_record_free(void *ptr) {
   CheckingRAII nocheck;
-  CilkSanImpl.mark_free(ptr);
+  if (!should_check()) {
+    CilkSanImpl.mark_free(ptr);
+    return;
+  }
+  const size_t *size = CilkSanImpl.malloc_sizes.get((uintptr_t)ptr);
+  if (CilkSanImpl.malloc_sizes.contains((uintptr_t)ptr)) {
+    if (!is_execution_parallel()) {
+      CilkSanImpl.clear_alloc((size_t)ptr, *size);
+      CilkSanImpl.clear_shadow_memory((size_t)ptr, *size);
+    } else {
+      // Treat a free as a write to all freed addresses.  This way the tool will
+      // report a race if an operation tries to access a location that was freed
+      // in parallel.
+      CilkSanImpl.record_free((uintptr_t)ptr, *size, UNKNOWN_CSI_ID, MAType_t::FREE);
+    }
+    CilkSanImpl.malloc_sizes.remove((uintptr_t)ptr);
+  }
 }
 
 // FIXME: Currently these dynamic interposers are never used, because common

--- a/test/cilksan/TestCases/write-free-race.cpp
+++ b/test/cilksan/TestCases/write-free-race.cpp
@@ -1,0 +1,35 @@
+// RUN: %clangxx_cilksan -fopencilk -O0 -g %s -o %t
+// RUN: %run %t 2>&1 | FileCheck %s
+// RUN: %clangxx_cilksan -fopencilk -Og -g %s -o %t
+// RUN: %run %t 2>&1 | FileCheck %s
+
+#include <cstdlib>
+
+int constexpr size = 1 << 10;
+
+__attribute__((noinline))
+void f(int* ptr) {
+  free(ptr); 
+}
+
+__attribute__((noinline))
+void g(int * ptr) {
+  ptr[0] = 7;
+}
+
+int main() {
+  int* arr = (int*)malloc(sizeof(int) * size);
+  cilk_spawn g(arr);
+  cilk_spawn f(arr);
+  return 0;
+}
+
+// CHECK: Race detected
+// CHECK-NEXT: * Write {{[0-9a-f]+}} g
+// CHECK-NEXT: to variable
+// CHECK-NEXT: Spawn {{[0-9a-f]+}} main
+// CHECK-NEXT: * Free
+// CHECK-NEXT: Call {{[0-9a-f]+}} main
+
+// CHECK: Cilksan detected 1 distinct races.
+// CHECK-NEXT: Cilksan suppressed 0 duplicate race reports.


### PR DESCRIPTION
This PR fixes an issue where Cilksan would fail to catch a race between a write and a `free()` in a simple program compiled without optimizations.