### PR TITLE
[cilksan] Move reducer classes into cilk namespace.

### DIFF
--- a/cilksan/cilksan_internal.h
+++ b/cilksan/cilksan_internal.h
@@ -11,8 +11,12 @@
 #include "locksets.h"
 #include "shadow_mem_allocator.h"
 #include "stack.h"
+#include <cilk/reducer>
 #include <cstdio>
 #include <unordered_map>
+
+using cilk::reducer_base;
+using cilk::reducer_callbacks;
 
 extern bool CILKSAN_INITIALIZED;
 
@@ -176,14 +180,14 @@ public:
 
   // Create a new reducer view.
   void *create_reducer_view_0(hyper_table *__restrict__ reducer_views,
-                              __reducer_base *key) {
+                              reducer_base *key) {
     // Create a new view and initialize it with the identity function.
-    size_t size = key->size();
+    size_t size = key->view_size();
     void *new_view = malloc(size);
     DBG_TRACE(REDUCER, "create_reducer_view_0(%p): created view %p -> %p\n",
               (void *)reducer_views, (void *)key, new_view);
     mark_alloc(new_view, size);
-    __reducer_base *base = key->identity(new_view);
+    reducer_base *base = key->identity(new_view);
     // Insert the new view into the local hypertable.
     hyper_table::bucket new_bucket = {
         .key = (uintptr_t)key,
@@ -192,12 +196,12 @@ public:
     assert(success && "create_reducer_view failed to insert new reducer.");
 
     // Return the new view.
-    return new_view;
+    return base;
   }
 
   void *create_reducer_view_1(hyper_table *__restrict__ reducer_views,
                               uintptr_t key,
-                              const __reducer_callbacks &callbacks) {
+                              const reducer_callbacks &callbacks) {
     // Create a new view and initialize it with the identity function.
     void *new_view = malloc(callbacks.size);
     DBG_TRACE(REDUCER, "create_reducer_view_1(%p): created view %p -> %p\n",

--- a/cilksan/hyperobject_base.h
+++ b/cilksan/hyperobject_base.h
@@ -2,6 +2,7 @@
 #ifndef _HYPEROBJECT_BASE
 #define _HYPEROBJECT_BASE
 
+#include "cilk/cilk_api.h"
 #include <cilk/reducer>
 #include <variant>
 
@@ -13,18 +14,24 @@
 // gets them as parameters.
 //
 // TODO: For small reducer views of size less than sizeof(void *),
-// consider storing the view directly within the reducer_data.
+// consider storing the view directly within the reducer_data
 // structure.
 // - Problem: A reducer_data structure may move around in the hash
 //   table as other reducers are inserted.  As a result, a pointer to
 //   a view may be invalidated by other hyper_lookup operations.
 // - Problem: Need a way to keep track of whether the view in a
 //   reducer_data is storing a pointer to the view or the view itself.
+
+namespace cilk {
+
 struct reducer_data {
-  void *view = nullptr;
-  std::variant<__reducer_base *, const std::function<void(void *, void *)> *,
-               void (*)(void *, void *)>
-      extra;
+    void *view = nullptr;
+    std::variant<
+        reducer_base *,
+        const reduce_fn *,
+        __cilk_c_reduce_fn *
+        > extra;
 };
 
+} // namespace cilk
 #endif /* _HYPEROBJECT_BASE */

--- a/cilksan/hypertable.h
+++ b/cilksan/hypertable.h
@@ -6,6 +6,8 @@
 #include <cassert>
 #include <cstdint>
 
+using cilk::reducer_data;
+
 // Helper methods for testing and setting keys.
 static const uintptr_t KEY_EMPTY = 0UL;
 static const uintptr_t KEY_DELETED = ~0UL;

--- a/cilksan/reducers.cpp
+++ b/cilksan/reducers.cpp
@@ -13,6 +13,10 @@
 
 // Hooks for handling reducer hyperobjects.
 
+using cilk::reducer_base;
+using cilk::reducer_callbacks;
+using cilk::reduce_fn;
+
 template <typename ExtraTy>
 static void reducer_register(const csi_id_t call_id, unsigned MAAP_count,
                              void *key, ExtraTy *extra) {
@@ -43,14 +47,14 @@ __csan_llvm_reducer_register(const csi_id_t call_id, const csi_id_t func_id,
   START_HOOK(call_id);
   switch (type) {
     case 0: {
-      __reducer_base *rb = static_cast<__reducer_base *>(key);
+      reducer_base *rb = static_cast<reducer_base *>(key);
       reducer_register(call_id, MAAP_count, key, rb);
       break;
     }
     case 1: {
-      __reducer_callbacks *cb =
-          static_cast<__reducer_callbacks *>(data);
-      reducer_register(call_id, MAAP_count, key, static_cast<__cilk_reduce_fn *>(&cb->reduce));
+      reducer_callbacks *cb =
+          static_cast<reducer_callbacks *>(data);
+      reducer_register(call_id, MAAP_count, key, static_cast<reduce_fn *>(&cb->reduce));
       break;
     }
     case 2: {
@@ -125,7 +129,7 @@ CILKSAN_API void *__csan_llvm_hyper_lookup_0(const csi_id_t call_id,
                                              const csi_id_t func_id,
                                              unsigned MAAP_count,
                                              const call_prop_t prop, void *view,
-                                             __reducer_base *key) {
+                                             reducer_base *key) {
   auto result =
       hyper_lookup_common(call_id, func_id, MAAP_count, prop, view, key);
   if (result.first || result.second == nullptr)
@@ -138,7 +142,7 @@ CILKSAN_API void *
 __csan_llvm_hyper_lookup_1(const csi_id_t call_id, const csi_id_t func_id,
                            unsigned MAAP_count, const call_prop_t prop,
                            void *view, void *key,
-                           const __reducer_callbacks &callbacks) {
+                           const reducer_callbacks &callbacks) {
   auto result =
       hyper_lookup_common(call_id, func_id, MAAP_count, prop, view, key);
   if (result.first || result.second == nullptr)
@@ -218,28 +222,24 @@ void CilkSanImpl_t::reduce_local_views() {
       // Custom version of hyper_table::bucket::reduce() to reduce view with key
       // in the same bucket.  The key points to the leftmost view.
       reducer_data rd = b.data;
-      if (std::holds_alternative<__reducer_base *>(rd.extra)) {
-        __reducer_base *leftmost =
-            static_cast<__reducer_base *>(reinterpret_cast<void *>(b.key));
-        __reducer_base *left_r = leftmost;
-        __reducer_base *right_r = std::get<__reducer_base *>(rd.extra);
+      if (std::holds_alternative<reducer_base *>(rd.extra)) {
+        reducer_base *leftmost =
+            static_cast<reducer_base *>(reinterpret_cast<void *>(b.key));
+        reducer_base *left_r = leftmost;
+        reducer_base *right_r = std::get<reducer_base *>(rd.extra);
         leftmost->reduce(left_r, right_r);
-        right_r->~__reducer_base();
-      } else if (std::holds_alternative<const __cilk_reduce_fn *>(rd.extra)) {
-        const __cilk_reduce_fn *reduce_fn =
-            std::get<const __cilk_reduce_fn *>(rd.extra);
-        (*reduce_fn)(left_view, right_view);
+        right_r->~reducer_base();
+      } else if (std::holds_alternative<const cilk::reduce_fn *>(rd.extra)) {
+        (*std::get<const cilk::reduce_fn *>(rd.extra))(left_view, right_view);
       } else {
-        void (*reduce_fn)(void *, void *) =
-            std::get<void (*)(void *, void *)>(rd.extra);
-        reduce_fn(left_view, right_view);
+        std::get<__cilk_c_reduce_fn *>(rd.extra)(left_view, right_view);
       }
-      rd.extra = (__reducer_base *)nullptr;
+      rd.extra = (reducer_base *)nullptr;
       rd.view = nullptr;
+      // Free the right view.
+      free(right_view);
+      mark_free(right_view);
     }
-    // Free the right view.
-    free(right_view);
-    mark_free(right_view);
     keysToRemove.push_back(b.key);
   }
   enable_checking();
@@ -257,30 +257,26 @@ void CilkSanImpl_t::reduce_local_views() {
 }
 
 void hyper_table::bucket::reduce(bucket *left, bucket *right) {
-    assert(left->data.extra.index() == right->data.extra.index());
-    void *left_view = left->data.view, *right_view = right->data.view;
-    if (std::holds_alternative<__reducer_base *>(left->data.extra)) {
-        __reducer_base *leftmost =
-            static_cast<__reducer_base *>
-            (reinterpret_cast<void *>(left->key));
-        __reducer_base *left_r = std::get<__reducer_base *>(left->data.extra);
-        __reducer_base *right_r =
-            std::get<__reducer_base *>(right->data.extra);
-        leftmost->reduce(left_r, right_r);
-        right_r->~__reducer_base();
-    } else if (std::holds_alternative<const __cilk_reduce_fn *>(left->data.extra)) {
-        const __cilk_reduce_fn *reduce_fn =
-            std::get<const __cilk_reduce_fn *>(left->data.extra);
-        (*reduce_fn)(left_view, right_view);
-    } else {
-        void (*reduce_fn)(void *, void *) =
-            std::get<void (*)(void *, void *)>(left->data.extra);
-        reduce_fn(left_view, right_view);
-    }
-    right->data.extra = (__reducer_base *)nullptr;
-    right->data.view = nullptr;
-    // Free the right view.
-    free(right_view);
+  assert(left->data.extra.index() == right->data.extra.index());
+  void *left_view = left->data.view, *right_view = right->data.view;
+  if (std::holds_alternative<reducer_base *>(left->data.extra)) {
+    reducer_base *leftmost =
+        static_cast<reducer_base *>(reinterpret_cast<void *>(left->key));
+    reducer_base *left_r = std::get<reducer_base *>(left->data.extra);
+    reducer_base *right_r = std::get<reducer_base *>(right->data.extra);
+    leftmost->reduce(left_r, right_r);
+    right_r->~reducer_base();
+  } else if (std::holds_alternative<const cilk::reduce_fn *>(
+                 left->data.extra)) {
+    (*std::get<const cilk::reduce_fn *>(left->data.extra))(left_view,
+                                                           right_view);
+  } else {
+    std::get<__cilk_c_reduce_fn *>(left->data.extra)(left_view, right_view);
+  }
+  right->data.extra = (reducer_base *)nullptr;
+  right->data.view = nullptr;
+  // Free the right view.
+  free(right_view);
 }
 
 hyper_table *
@@ -343,7 +339,7 @@ hyper_table::merge_two_hyper_tables(CilkSanImpl_t *__restrict__ tool,
         bucket::reduce(&b, dst_bucket);
         tool->mark_free(dst_rd.view);
         dst_bucket->data = b.data;
-        b.data.extra = (__reducer_base *)nullptr;
+        b.data.extra = (reducer_base *)nullptr;
         b.data.view = nullptr;
       }
     }


### PR DESCRIPTION
This change fixes productivity-tools for the change in OpenCilk/cheetah#75. 